### PR TITLE
Add ignored unimplemented parameters to response

### DIFF
--- a/app/models/iiif_content_search_response.rb
+++ b/app/models/iiif_content_search_response.rb
@@ -13,7 +13,10 @@ class IiifContentSearchResponse
 
   def as_json(*_args)
     {
-      "@context": 'http://iiif.io/api/presentation/2/context.json',
+      "@context": [
+        'http://iiif.io/api/presentation/2/context.json',
+        'http://iiif.io/api/search/1/context.json'
+      ],
       "@id": request.original_url,
       "@type": 'sc:AnnotationList',
       "resources": resources.map(&:as_json)

--- a/app/models/iiif_content_search_response.rb
+++ b/app/models/iiif_content_search_response.rb
@@ -61,8 +61,7 @@ class IiifContentSearchResponse
   end
 
   def ignored_params
-    valid_iiif_params = %w[motivation date user]
-    valid_iiif_params.select { |param| controller.params.keys.include?(param) }
+    Settings.iiif.ignored_request_params.select { |param| controller.params.keys.include?(param) }
   end
 
   def resources

--- a/app/models/iiif_content_search_response.rb
+++ b/app/models/iiif_content_search_response.rb
@@ -30,7 +30,8 @@ class IiifContentSearchResponse
       within: {
         '@type': 'sc:Layer',
         first: first_page_url,
-        last: last_page_url
+        last: last_page_url,
+        ignored: ignored_params
       }
     }
     hash[:next] = next_page_url if next_page?
@@ -57,6 +58,11 @@ class IiifContentSearchResponse
 
   def next_page?
     search.num_found >= (search.start + search.rows)
+  end
+
+  def ignored_params
+    valid_iiif_params = %w[motivation date user]
+    valid_iiif_params.select { |param| controller.params.keys.include?(param) }
   end
 
   def resources

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,6 @@
+iiif:
+  ignored_request_params: [motivation, date, user]
+
 purl:
   canvas_url: 'https://purl.stanford.edu/%{druid}/iiif/canvas/%{resource}'
   public_xml_url: 'https://purl.stanford.edu/%{druid}.xml'

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe SearchController do
 
       data = JSON.parse(response.body)
 
-      expect(data).to include '@context' => 'http://iiif.io/api/presentation/2/context.json',
+      expect(data).to include '@context' => ['http://iiif.io/api/presentation/2/context.json',
+                                             'http://iiif.io/api/search/1/context.json'],
                               '@id' => 'http://test.host/x/search?q=y',
                               '@type' => 'sc:AnnotationList'
     end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -17,14 +17,15 @@ RSpec.describe SearchController do
     end
 
     it 'executes a search and transforms it into a content search response' do
-      get :search, params: { id: 'x', q: 'y' }
+      get :search, params: { id: 'x', q: 'y', motivation: 'painting' }
 
       data = JSON.parse(response.body)
 
       expect(data).to include '@context' => ['http://iiif.io/api/presentation/2/context.json',
                                              'http://iiif.io/api/search/1/context.json'],
-                              '@id' => 'http://test.host/x/search?q=y',
-                              '@type' => 'sc:AnnotationList'
+                              '@id' => 'http://test.host/x/search?motivation=painting&q=y',
+                              '@type' => 'sc:AnnotationList',
+                              'within' => include('ignored' => ['motivation'])
     end
 
     it 'includes resources for every hit' do

--- a/spec/models/iiif_content_search_response_spec.rb
+++ b/spec/models/iiif_content_search_response_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe IiifContentSearchResponse, type: :controller do
 
   describe '#as_json' do
     it 'has the expected json-ld properties' do
-      expect(response.as_json).to include "@context": 'http://iiif.io/api/presentation/2/context.json',
+      expect(response.as_json).to include "@context": ['http://iiif.io/api/presentation/2/context.json',
+                                                       'http://iiif.io/api/search/1/context.json'],
                                           "@id": 'http://test.host',
                                           "@type": 'sc:AnnotationList'
     end


### PR DESCRIPTION
Closes #31

This PR:
- takes non-implemented request parameters (e.g. `motivation`) and puts them in an `ignored` property
- adds Search API 1.0 to `context`

Sample query: `/cc842mn9348/search?q=trial&motivation=tagging&date=2017-06-06`
Returns:
```json
"@context": [
  "http://iiif.io/api/presentation/2/context.json",
  "http://iiif.io/api/search/0/context.json"
],
"@id": "http://localhost:3000/cc842mn9348/search?q=trial&motivation=tagging&date=2017-06-06",
"@type": "sc:AnnotationList",
```
```json
"within": {
  "@type": "sc:Layer",
  "first": "http://localhost:3000/cc842mn9348/search?start=0",
  "last": "http://localhost:3000/cc842mn9348/search?start=0",
  "ignored": [
    "motivation",
  "date"
  ]
}
```

  
  