### PR TITLE
Remove empty after, adds match to hit, and combines adjacent hits

### DIFF
--- a/app/models/iiif_content_search_response.rb
+++ b/app/models/iiif_content_search_response.rb
@@ -30,7 +30,7 @@ class IiifContentSearchResponse
     search.highlights.each do |id, hits|
       # Hit here refers to the Solr hit
       hits.each do |hit|
-        hit.to_enum(:scan, %r{<em>.*?</em>}).each do |*_match|
+        hit.gsub('</em> <em>', ' ').to_enum(:scan, %r{<em>.*?</em>}).each do |*_match|
           yield Resource.new(id, Regexp.last_match)
         end
       end

--- a/app/models/iiif_content_search_response.rb
+++ b/app/models/iiif_content_search_response.rb
@@ -84,7 +84,8 @@ class IiifContentSearchResponse
         '@type': 'search:Hit',
         'annotations': hit.annotation_urls,
         'before': hit.before,
-        'after': hit.after
+        'after': hit.after,
+        'match': hit.match
       }
     end
   end
@@ -131,6 +132,10 @@ class IiifContentSearchResponse
 
     def after
       tokenized_text(post_match).map(&:first).join(' ').strip
+    end
+
+    def match
+      tokenized_text(highlight).map(&:first).join(' ').strip
     end
 
     private

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -59,7 +59,8 @@ class Search
     Settings.solr.highlight_params.to_h.merge(
       fq: ["druid:#{id}"],
       rows: rows,
-      start: start
+      start: start,
+      'hl.tag.ellipsis' => ' ' # Gives the after block in missing cases
     )
   end
 

--- a/spec/models/iiif_content_search_response_spec.rb
+++ b/spec/models/iiif_content_search_response_spec.rb
@@ -114,6 +114,22 @@ thursday☞632,789,84,291']
         end
       end
     end
+    context 'with adjacent hits' do
+      let(:highlights) do
+        {
+          '' => [
+            'as☞1590.12,1094.11,46.81,33.89 <em>crimes☞1660.33,1094.11,140.42,3'\
+            '3.89</em> <em>against☞1824.15,1094.11,163.82,33.89</em> <em>humani'\
+            'ty,☞2011.38,1094.11,210.62,33.89</em> contrary☞674.90,1140.00,179.'\
+            '61,32.48 to☞899.41,1140.00,44.90,32.48'
+          ]
+        }
+      end
+
+      it 'combines together into a single hit' do
+        expect(response.resources.to_a[0].match).to eq 'crimes against humanity,'
+      end
+    end
 
     it 'has hits with additional context for an ALTO resource' do
       expect(response.as_json).to include hits: include("@type": 'search:Hit',

--- a/spec/models/iiif_content_search_response_spec.rb
+++ b/spec/models/iiif_content_search_response_spec.rb
@@ -34,6 +34,20 @@ Endcap☞632,789,84,291'],
     end
   end
 
+  describe '#match' do
+    context 'with truncated coordinate payloads in the highlight' do
+      let(:highlights) do
+        {
+          'x/truncated_highlight_coords/alto' => ['0,2 George☞639,129,79,243 <em>Stirling’s☞633,426,84,300</em>']
+        }
+      end
+
+      it 'strips leading payload fragments' do
+        expect(response.resources.first.match).to eq 'Stirling’s'
+      end
+    end
+  end
+
   describe '#as_json' do
     it 'has the expected json-ld properties' do
       expect(response.as_json).to include "@context": ['http://iiif.io/api/presentation/2/context.json',
@@ -108,7 +122,8 @@ thursday☞632,789,84,291']
                                                           'https://purl.stanford.edu/x/iiif/canvas/y/text/at/633,426,84,300'
                                                         ],
                                                         "before": '',
-                                                        "after": 'Heritage')
+                                                        "after": 'Heritage',
+                                                        "match": 'George Stirling’s')
     end
 
     it 'has hits with additional context for a plain text resource' do
@@ -117,7 +132,8 @@ thursday☞632,789,84,291']
                                                           'https://purl.stanford.edu/x/iiif/canvas/y/text/at/0,0,0,0'
                                                         ],
                                                         "before": '',
-                                                        "after": 'OF THE COUNCIL')
+                                                        "after": 'OF THE COUNCIL',
+                                                        "match": 'MEMBERS')
     end
 
     it 'has basic pagination context' do


### PR DESCRIPTION
Closes #55 

Note, uv still shows the match count on a page a bit different than we might expect. This does not seem to be calculated from the `hits` section of the response.
![screen shot 2018-04-12 at 4 46 55 pm](https://user-images.githubusercontent.com/1656824/38707978-268284ac-3e71-11e8-9983-0a838dca59db.png)

As far as I can tell, this has no user facing changes/implications to UV in its current state.

## Fixture object cc842mn9348

## Before
![hits](https://user-images.githubusercontent.com/73732/38333370-48216e8a-380d-11e8-9701-f5a7963d2040.png)

## After
![screen shot 2018-04-12 at 4 45 45 pm](https://user-images.githubusercontent.com/1656824/38707954-fab303b0-3e70-11e8-944d-4bfda22ce968.png)
