### PR TITLE
Stop using sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,5 @@ gem 'nokogiri'
 gem 'okcomputer'
 gem 'parallel'
 gem 'racecar', '~> 2.8'
-gem 'redis', '~> 5.0'
-gem 'redlock'
 gem 'rsolr'
-gem 'sidekiq', '~> 7.0'
 gem 'whenever', require: false # Work around https://github.com/javan/whenever/issues/831

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,6 @@ GEM
     config (5.1.0)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.4)
     debug (1.9.1)
@@ -272,12 +271,6 @@ GEM
       rake (> 12)
     rdoc (6.6.2)
       psych (>= 4.0.0)
-    redis (5.0.8)
-      redis-client (>= 0.17.0)
-    redis-client (0.19.1)
-      connection_pool
-    redlock (2.0.6)
-      redis-client (>= 0.14.1, < 1.0.0)
     regexp_parser (2.9.0)
     reline (0.4.2)
       io-console (~> 0.5)
@@ -334,11 +327,6 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    sidekiq (7.2.0)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.14.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -391,15 +379,12 @@ DEPENDENCIES
   puma (~> 5.0)
   racecar (~> 2.8)
   rails (~> 7.0.0)
-  redis (~> 5.0)
-  redlock
   rsolr
   rspec-rails
   rubocop
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  sidekiq (~> 7.0)
   simplecov
   solr_wrapper
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Content can be indexed from the Rails console:
 
 ```
 > druid = 'bb034nj7139' # e.g.
-> IndexFullTextContentJob.perform_now(druid)
+> IndexFullTextContent.run(druid)
 ```
 You may need to commit this separately
 

--- a/app/models/concerns/locking.rb
+++ b/app/models/concerns/locking.rb
@@ -2,33 +2,7 @@
 
 # Basic lock manager
 module Locking
-  def with_lock(id, &block)
-    if Rails.application.config.active_job.queue_adapter == :sidekiq
-      with_redlock(id, &block)
-    else
-      with_simple_lock(id, &block)
-    end
-  end
-
-  private
-
-  def with_redlock(id)
-    Sidekiq.redis_pool.with do |redis|
-      lock_manager = Redlock::Client.new([redis], { retry_count: 60, retry_delay: 1000 })
-
-      # if the lock is available the first try
-      lock_manager.lock(id, 60000, { extend: { value: SecureRandom.uuid } }) do |locked|
-        return yield(true) if locked
-      end
-
-      # otherwise, let the lock requestor know that someone else beat them to the punch
-      lock_manager.lock(id, 60000) do |locked|
-        yield(false) if locked
-      end
-    end
-  end
-
-  def with_simple_lock(id)
+  def with_lock(id)
     lock_file = Rails.root.join('tmp', id)
 
     resp = File.open(lock_file, 'w') do |f|

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -80,7 +80,7 @@ class Search
     with_lock("indexing_lock_#{id.parameterize}") do |locked_on_first_try|
       next if !locked_on_first_try || any_results_for_document?
 
-      IndexFullTextContentJob.perform_now(id, commit: true)
+      IndexFullTextContent.run(id, commit: true)
     end
   end
 

--- a/app/services/garbage_collect_index.rb
+++ b/app/services/garbage_collect_index.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
 # Remove content for a druid from the solr index
-class GarbageCollectJob < ApplicationJob
-  def perform
+class GarbageCollectIndex
+  def self.run
     response['response']['docs'].each do |doc|
       Search.client.delete_by_query("druid:#{doc['druid']}", params: { commit: true })
     end
   end
 
-  private
-
-  def response
+  def self.response
     Search.client.get(
       Settings.solr.highlight_path,
       params: {
@@ -21,4 +19,5 @@ class GarbageCollectJob < ApplicationJob
       }
     )
   end
+  private_class_method :response
 end

--- a/app/services/index_full_text_content.rb
+++ b/app/services/index_full_text_content.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # Index full text content into the solr index
-class IndexFullTextContentJob < ApplicationJob
-  def perform(druid, options = { commitWithin: 5000 })
+class IndexFullTextContent
+  def self.run(druid, options = { commitWithin: 5000 })
     Search.client.update(
       data: {
         delete: { query: "druid:#{RSolr.solr_escape(druid)}" },

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -52,11 +52,3 @@ set :whenever_roles, [:indexer]
 # Manage racecar via systemd (from dlss-capistrano gem)
 set :racecar_systemd_role, :indexer
 set :racecar_systemd_use_hooks, true
-
-namespace :deploy do
-  after :restart, :restart_sidekiq do
-    on roles(:app) do
-      sudo :systemctl, "restart", "sidekiq-*", raise_on_non_zero_exit: false
-    end
-  end
-end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -4,6 +4,3 @@ OkComputer.mount_at = false
 Rails.application.reloader.to_prepare do
   OkComputer::Registry.register "solr", OkComputer::HttpCheck.new(Search.client.uri.to_s.sub(/\/$/, '') + '/admin/ping')
 end
-
-# Built-in Sidekiq check
-OkComputer::Registry.register 'feature-sidekiq', OkComputer::SidekiqLatencyCheck.new('default', 4.hours)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,5 @@ Rails.application.routes.draw do
   root to: 'search#home'
   get '/:id/search', to: 'search#search', as: :iiif_content_search
 
-  require 'sidekiq/web'
-  mount Sidekiq::Web => '/sidekiq'
-
   mount OkComputer::Engine, at: "/status"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,5 +2,5 @@ job_type :runner,  "cd :path && :environment_variable=:environment bin/rails run
 
 # Garbage collect the index
 every '15 * * * *' do
-  runner 'GarbageCollectJob.perform_now'
+  runner 'GarbageCollectIndex.run'
 end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe Search do
     it 'kicks off indexing if no results were found' do
       client = instance_double(RSolr::Client, get: { 'response' => { 'numFound' => 0 }, 'highlighting' => {} })
       allow(described_class).to receive(:client).and_return(client)
-      allow(IndexFullTextContentJob).to receive(:perform_now)
+      allow(IndexFullTextContent).to receive(:run)
       search.highlights
-      expect(IndexFullTextContentJob).to have_received(:perform_now).with('x', commit: true)
+      expect(IndexFullTextContent).to have_received(:run).with('x', commit: true)
     end
   end
 

--- a/spec/services/index_full_text_content_spec.rb
+++ b/spec/services/index_full_text_content_spec.rb
@@ -2,12 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe IndexFullTextContentJob do
-  describe '#perform' do
+RSpec.describe IndexFullTextContent do
+  describe '#run' do
     it 'adds content to solr' do
       allow(Search).to receive(:client).and_return(instance_double(RSolr::Client, update: nil))
       allow(PurlObject).to receive(:new).and_return(instance_double(PurlObject, to_solr: [{ id: 1, druid: 'x' }]))
-      described_class.perform_now('x')
+      described_class.run('x')
       expect(Search.client).to have_received(:update).with(
         data: {
           delete: { query: 'druid:x' },


### PR DESCRIPTION
Because we never use it to run any jobs
Fixes #449 

See log messages indicating we are just using the async adapter:
```
I, [2023-04-11T09:15:02.013819 #1507467]  INFO -- : [ActiveJob] [GarbageCollectJob] [16d7b9c3-c24b-4690-90e8-1c25d12adf89] Performing GarbageCollectJob (Job ID: 16d7b9c3-c24b-4690-90e8-1c25d12adf89) from Async(default) enqueued at
```

```
contentsearch@sul-contentsearch-prod-a:~/contentsearch/current$ bin/rails c -e p
Loading production environment (Rails 7.0.4.3)
3.1.0 :001 > Rails.application.config.active_job.queue_adapter
 => :async
```