### PR TITLE
Remove the prefix from the druid

### DIFF
--- a/app/consumers/publish_consumer.rb
+++ b/app/consumers/publish_consumer.rb
@@ -9,6 +9,6 @@ class PublishConsumer < Racecar::Consumer
   def process(message)
     data = JSON.parse(message.value)
 
-    Search.client.delete_by_query("druid:#{data['druid']}", params: { commit: true })
+    Search.client.delete_by_query("druid:#{data['druid'].delete_prefix('druid:')}", params: { commit: true })
   end
 end

--- a/spec/consumers/publish_consumer_spec.rb
+++ b/spec/consumers/publish_consumer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PublishConsumer do
     let(:message_value) { { druid: 'druid:123' }.to_json }
 
     it 'creates a delete content job' do
-      expect(Search.client).to have_received(:delete_by_query).with('druid:druid:123', params: { commit: true })
+      expect(Search.client).to have_received(:delete_by_query).with('druid:123', params: { commit: true })
     end
   end
 end


### PR DESCRIPTION
This prevents an error like `Error: org.apache.solr.search.SyntaxError: Cannot parse 'druid:druid:cw487hq3615'`