### PR TITLE
We only need to use the message key to process publish events

### DIFF
--- a/spec/consumers/publish_consumer_spec.rb
+++ b/spec/consumers/publish_consumer_spec.rb
@@ -8,43 +8,14 @@ RSpec.describe PublishConsumer do
   describe '#process' do
     before do
       allow(Search).to receive(:client).and_return(instance_double(RSolr::Client, delete_by_query: nil))
+      consumer.process(message)
     end
 
-    let(:message) { instance_double(Racecar::Message, value: message_value) }
+    let(:key) { 'druid:123' }
+    let(:message) { instance_double(Racecar::Message, key: key) }
 
-    context 'when the message has a value' do
-      let(:message_value) { { druid: 'druid:123' }.to_json }
-      let(:message) { instance_double(Racecar::Message, value: message_value) }
-
-      before do
-        consumer.process(message)
-      end
-
-      it 'creates a delete content job' do
-        expect(Search.client).to have_received(:delete_by_query).with('druid:123', params: { commit: true })
-      end
-    end
-
-    context 'when the message value is nil' do
-      let(:headers) { { foo: 'bar' } }
-      let(:timestamp) { '19990404' }
-      let(:offset) { '101010' }
-      let(:key) { 'dr712bb2404' }
-
-      let(:message) { instance_double(Racecar::Message, value: nil, key: key, offset: offset, create_time: timestamp, headers: headers) }
-
-      before do
-        allow(Honeybadger).to receive(:notify)
-        consumer.process(message)
-      end
-
-      it 'logs to honeybadger' do
-        expect(Honeybadger).to have_received(:notify).with('Blank message received',
-                                                           context: { message_headers: headers,
-                                                                      message_timestamp: timestamp,
-                                                                      message_key: key,
-                                                                      message_offset: offset })
-      end
+    it 'creates a delete content job' do
+      expect(Search.client).to have_received(:delete_by_query).with('druid:123', params: { commit: true })
     end
   end
 end


### PR DESCRIPTION
We don't want to process the message value, because the value is nil if this was publishing a 'dark' object