### PR TITLE
Avoid sending out cron emails with unhelpful messages

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,4 @@
-job_type :runner,  "cd :path && :environment_variable=:environment bin/rails runner -e :environment ':task' :output"
+job_type :runner,  "cd :path && RAILS_LOG_LEVEL=warn :environment_variable=:environment bin/rails runner -e :environment ':task' :output"
 
 # Garbage collect the index
 every '15 * * * *' do


### PR DESCRIPTION
This avoids emails like this:
```
I, [2024-05-30T07:15:02.940329 #578321]  INFO -- : [ActiveJob] [GarbageCollectJob] [255fa72e-a5f6-47cc-9e6b-7758b5172b0f] Performing GarbageCollectJob (Job ID: 255fa72e-a5f6-47cc-9e6b-7758b5172b0f) from Async(default)
I, [2024-05-30T07:15:02.969570 #578321]  INFO -- : [ActiveJob] [GarbageCollectJob] [255fa72e-a5f6-47cc-9e6b-7758b5172b0f] Performed GarbageCollectJob (Job ID: 255fa72e-a5f6-47cc-9e6b-7758b5172b0f) from Async(default) in 29.44ms
```