### PR TITLE
Update rdkafka gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'debug'
   gem 'rspec-rails'
 
   gem 'simplecov'
@@ -50,7 +50,7 @@ group :deployment do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data', platforms: %i[windows jruby]
 
 gem 'config'
 gem 'honeybadger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,17 +273,17 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
-    rdkafka (0.22.1)
+    rdkafka (0.22.2)
       ffi (~> 1.15)
       logger
       mini_portile2 (~> 2.6)
       rake (> 12)
-    rdkafka (0.22.1-arm64-darwin)
+    rdkafka (0.22.2-arm64-darwin)
       ffi (~> 1.15)
       logger
       mini_portile2 (~> 2.6)
       rake (> 12)
-    rdkafka (0.22.1-x86_64-linux-gnu)
+    rdkafka (0.22.2-x86_64-linux-gnu)
       ffi (~> 1.15)
       logger
       mini_portile2 (~> 2.6)


### PR DESCRIPTION
Applies this fix https://github.com/karafka/rdkafka-ruby/pull/649 in rdkafka v0.22.2 that allows the gem to install correctly on our version of Ubuntu.